### PR TITLE
On a new clone the build directory is needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 website:
+	mkdir -p build
 	pandoc -s -S -c style/pan-am.css README.md -o build/index.html
 	cp -r style images build/
 publish: website pdf html


### PR DESCRIPTION
When I clone the repository from github a make fails, this because the build directory
is not there yet.
